### PR TITLE
Update lmdeploy.md

### DIFF
--- a/lmdeploy/lmdeploy.md
+++ b/lmdeploy/lmdeploy.md
@@ -96,7 +96,7 @@ $ conda activate lmdeploy
 lmdeploy 没有安装，我们接下来手动安装一下，建议安装最新的稳定版。
 
 ```bash
-$ pip install 'lmdeploy[all]==v0.1.0'
+$ pip install lmdeploy
 ```
 
 由于默认安装的是 runtime 依赖包，但是我们这里还需要部署和量化，所以，这里选择 `[all]`。然后可以再检查一下 lmdeploy 包，如下图所示。


### PR DESCRIPTION
原本的lmdeploy[all]==v0.1.0会出现以下错误
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-eq4foggy/flash-attn_3bc80bb81df347f78f499c5de67888d5/setup.py", line 9, in <module>
          from packaging.version import parse, Version
      ModuleNotFoundError: No module named 'packaging'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata. ╰─> See above for output.

note: This is an issue with the